### PR TITLE
changed signatures to be compileable under vs2010

### DIFF
--- a/dosbox_debmod.cpp
+++ b/dosbox_debmod.cpp
@@ -1070,13 +1070,13 @@ int idaapi dosbox_debmod_t::dbg_thread_get_sreg_base(
 }
 
 //--------------------------------------------------------------------------
-bool idaapi dosbox_debmod_t::refresh_hwbpts(void)
+bool dosbox_debmod_t::refresh_hwbpts(void)
 {
   return 0; // not implemented
 }
 
 //--------------------------------------------------------------------------
-HANDLE idaapi dosbox_debmod_t::get_thread_handle(thid_t tid)
+HANDLE dosbox_debmod_t::get_thread_handle(thid_t tid)
 {
   return (HANDLE)tid; // there are no thread handles
 }

--- a/dosbox_debmod.h
+++ b/dosbox_debmod.h
@@ -120,8 +120,8 @@ public:
   virtual ssize_t idaapi dbg_read_file(int fn, uint32 off, void *buf, size_t size);
   virtual ssize_t idaapi dbg_write_file(int fn, uint32 off, const void *buf, size_t size);
   virtual int idaapi get_system_specific_errno(void) const;
-  virtual bool idaapi refresh_hwbpts(void);
-  virtual HANDLE idaapi get_thread_handle(thid_t tid);
+  virtual bool refresh_hwbpts(void);
+  virtual HANDLE get_thread_handle(thid_t tid);
   virtual int idaapi dbg_is_ok_bpt(bpttype_t type, ea_t ea, int len);
 
   bool idaapi close_remote(void);


### PR DESCRIPTION
i get an C2695 compile error with vs2010 for these two methods
http://msdn.microsoft.com/en-us/library/z6twcwss(v=vs.71).aspx

the "idaapi" for calling convention needs to be in the base class or else the compiler decides what to use - but that will change the external idasdk plugin code - ok?
